### PR TITLE
feat(data): implement HDF5 dataset merging and testing

### DIFF
--- a/denspp/offline/data_call/merge_datasets.py
+++ b/denspp/offline/data_call/merge_datasets.py
@@ -1,18 +1,50 @@
 from copy import deepcopy
 from datetime import datetime
-from glob import glob
 from logging import Logger, getLogger
 from os import makedirs
-from os.path import exists, join
 from pathlib import Path
 from shutil import rmtree
 
+import h5py
 import numpy as np
 from tqdm import tqdm
 
 from denspp.offline import check_keylist_elements_any, get_path_to_project
-from denspp.offline.data_call import DataFromFile, SettingsData
-from denspp.offline.preprocessing import FrameWaveform
+from denspp.offline.data_call import CollectorH5, DataFromFile, LabelCollector, SettingsData
+
+""" --------------------------------------------------------------------------------------------
+INPUT DATA FILE STRUCTURE:
+
+├── data_raw      # Raw signals
+├── evnt_xpos     # Event positions in the raw signal
+├── evnt_id       # Original labels / classes
+├── fs_used       # Sampling rate
+├── data_name     # Name of the dataset
+└── label_exist   # Information, if labels exist
+
+
+TEMPORARY DATA FILE STRUCTURE (temp_merge/):
+
+temp_merge/
+└── YYYY-MM-DD_Dataset-<data_name>.h5
+    ├── waveform
+    ├── xpos
+    ├── label
+    └── sampling_rate
+
+
+FINAL DATA FILE STRUCTURE (dataset/):
+
+dataset/
+└── YYYY-MM-DD_Dataset-<data_name>_Merged.h5
+    ├── data
+    ├── class
+    ├── position
+    ├── sampling_rate
+    ├── create_time
+    ├── label_mapping_keys      # original labels
+    └── label_mapping_values    # new labels
+------------------------------------------------------------------------------------------------------------------"""
 
 
 class MergeDataset:
@@ -43,134 +75,273 @@ class MergeDataset:
     def _check_right_pipeline(self) -> None:
         if not check_keylist_elements_any(
             keylist=dir(self._pipeline),
-            elements=["run_preprocessing", "run_classifier", "settings"],
+            elements=["run_preprocessor", "run_classifier", "settings"],
         ):
             raise ImportError(
-                "Wrong pipeline is implemented. It should include 'run_preprocessing' and 'run_classifier'."
+                "Wrong pipeline is implemented. It should include 'run_preprocessor' and 'run_classifier'."
             )
 
     def _generate_folder(self) -> None:
-        if exists(self._path2save):
+        if Path(self._path2save).exists():
             rmtree(self._path2save)
         makedirs(self._path2save, exist_ok=True)
 
-    def _save_results(self, data: dict, path2folder: str, file_name: str) -> str:
-        file_name = f"{file_name}.npy"
-        path2file = join(path2folder, file_name)
-        np.save(path2file, data, allow_pickle=True)
-        self._logger.info(f"Saving file in: {file_name}")
-        return path2file
+    def _append_to_temp_dataset(
+        self,
+        h5f: h5py.File,
+        name: str,
+        data,
+        dtype,
+    ) -> None:
+        """Appends one sample to a flat extendable temporary HDF5 dataset."""
+        data = np.asarray(data, dtype=dtype)
 
-    def _iteration_save_results(self, data: list, data_name: str) -> None:
-        create_time = datetime.now().strftime("%Y-%m-%d")
-        data_save = {"frames": data}
-        self._save_results(
-            data=data_save,
-            path2folder=self._path2save,
-            file_name=f"{create_time}_Dataset-{data_name}",
-        )
+        if name not in h5f:
+            if data.ndim == 0:
+                shape = (0,)
+                maxshape = (None,)
+                chunks = (8,)
+            else:
+                shape = (0, *data.shape)
+                maxshape = (None, *data.shape)
+                chunks = (8, *data.shape)
 
-    def _get_frames_from_labeled_dataset(self, data: DataFromFile, xpos_offset: int = 0) -> list:
-        self._logger.info(f"\nProcessing file: {data.data_name}")
-        pipeline = self._pipeline(data.fs_used, False)
+            h5f.create_dataset(
+                name=name,
+                shape=shape,
+                maxshape=maxshape,
+                chunks=chunks,
+                dtype=dtype,
+                compression="gzip",
+                compression_opts=4,
+            )
 
-        frames_extracted = list()
-        for rawdata, xposition, label in tqdm(
-            zip(data.data_raw, data.evnt_xpos, data.evnt_id),
-            ncols=100,
-            desc="Progress: ",
-        ):
-            xpos_scaler = pipeline.fs_ana / pipeline.fs_ana
-            xpos_updated = np.floor(xpos_scaler * xposition).astype("int")
-            result = pipeline.run_preprocessor(rawdata, xpos_updated, xpos_offset)
+        dataset = h5f[name]
+        old_len = dataset.shape[0]
+        dataset.resize(old_len + 1, axis=0)
+        dataset[old_len] = data
 
-            frame_new: FrameWaveform = result["frames"]
-            frame_new.label = label
-            frames_extracted.append(frame_new)
-            del frame_new
-        return frames_extracted
+    def _save_frame_to_temp(self, frame, frame_index: int, h5f: h5py.File) -> None:
+        """Saves frame content to the already opened flat temporary HDF5 file."""
+        if "sampling_rate" not in h5f:
+            h5f.create_dataset("sampling_rate", data=np.asarray(frame.sampling_rate))
 
-    def _get_frames_from_unlabeled_dataset(self, data: DataFromFile, **kwargs) -> list:
-        self._logger.info(f"\nProcessing file: {data.data_name}")
-        pipeline = self._pipeline(data.fs_used, False)
+        waveforms = np.asarray(frame.waveform, dtype=np.float32)
+        if waveforms.ndim == 1:
+            waveforms = waveforms[np.newaxis, :]
 
-        frames_extracted = list()
-        for rawdata in tqdm(data.data_raw, ncols=100, desc="Progress: "):
-            result = pipeline.run_preprocessor(rawdata)
+        positions = np.atleast_1d(np.asarray(frame.xpos, dtype=np.int32))
+        labels = np.atleast_1d(np.asarray(frame.label, dtype=np.int32))
 
-            frame_new: FrameWaveform = result["frames"]
-            frames_extracted.append(frame_new)
-            del frame_new
-        return frames_extracted
+        if not (len(waveforms) == len(positions) == len(labels)):
+            raise ValueError(
+                f"Shape mismatch while saving temporary frame {frame_index}: \n"
+                f"waveforms={len(waveforms)}, \n"
+                f"positions={len(positions)}, \n"
+                f"labels={len(labels)} \n"
+            )
 
-    def get_frames_from_dataset(self, process_points: list = [], xpos_offset: int = 0) -> None:
+        for waveform, xpos, label in zip(waveforms, positions, labels):
+            self._append_to_temp_dataset(h5f, "waveform", waveform, np.float32)
+            self._append_to_temp_dataset(h5f, "xpos", int(xpos), np.int32)
+            self._append_to_temp_dataset(h5f, "label", int(label), np.int32)
+
+    def _iter_frames_from_temp(self, path2file: str):
+        """Iterator for reading the samples of a temporary HDF5 file.
+        Only one waveform is held in memory at a time.
+        """
+        with h5py.File(path2file, "r") as h5f:
+            waveforms = h5f["waveform"]
+            positions = h5f["xpos"]
+            labels = h5f["label"]
+            sampling_rate = float(h5f["sampling_rate"][()])
+
+            for index in range(len(waveforms)):
+                yield {
+                    "waveform": np.asarray(waveforms[index]),
+                    "xpos": np.asarray(positions[index]),
+                    "label": np.asarray(labels[index]),
+                    "sampling_rate": sampling_rate,
+                }
+
+    def get_frames_from_dataset(self, process_points: list | None = None, xpos_offset: int = 0) -> None:
         """Tool for loading datasets in order to generate one new dataset (Step 1)
         :param process_points:      Taking the datapoints of the selected data set to process
         :param xpos_offset:         Integer as position offset for shifting label position of an event (only apply if label exists)
         :return:                    None
         """
+        if process_points is None:
+            process_points = []
+
         self._generate_folder()
         current_index = 0
+        create_time = datetime.now().strftime("%Y-%m-%d")
+
         while True:
+            sets0 = deepcopy(self._settings)
             try:
-                sets0 = deepcopy(self._settings)
                 sets0.data_point = (
                     current_index if not len(process_points) else process_points[current_index]
                 )
+            except IndexError:
+                break
+
+            datahandler = None
+            try:
                 datahandler = self._dataloader(sets0)
                 datahandler.do_call()
-            except:
-                break
-            else:
                 datahandler.do_resample()
                 datahandler.do_cut()
-                data: DataFromFile = datahandler.get_data()
-                del datahandler
 
-                if data.label_exist:
-                    result = self._get_frames_from_labeled_dataset(data, xpos_offset=xpos_offset)
-                else:
-                    result = self._get_frames_from_unlabeled_dataset(data)
-                self._iteration_save_results(data=result, data_name=data.data_name)
-                current_index += 1
+                data: DataFromFile = datahandler.get_data()
+
+                # create temp file
+                temp_filename = f"{create_time}_Dataset-{data.data_name}.h5"
+                temp_path = Path(self._path2save) / temp_filename
+
+                with h5py.File(temp_path, "w") as h5f:
+                    frame_counter = 0
+
+                    if data.label_exist:
+                        # labeled dataset ------------------------------------------------------------------------------
+                        pipeline = self._pipeline(data.fs_used, False)
+                        for rawdata, xposition, label in tqdm(
+                            zip(data.data_raw, data.evnt_xpos, data.evnt_id),
+                            ncols=100,
+                            desc="Progress (labeled): ",
+                        ):
+                            xpos_scaler = pipeline.fs_ana / data.fs_used
+                            xpos_updated = np.floor(xpos_scaler * xposition).astype("int")
+                            result = pipeline.run_preprocessor(rawdata, xpos_updated, xpos_offset)
+                            frame_new = result["frames"]
+                            frame_new.label = label
+                            self._save_frame_to_temp(frame_new, frame_counter, h5f)
+                            frame_counter += 1
+                            del frame_new
+                    else:
+                        # unlabeled dataset ----------------------------------------------------------------------------
+                        pipeline = self._pipeline(data.fs_used, False)
+                        for rawdata in tqdm(data.data_raw, ncols=100, desc="Progress (unlabeled): "):
+                            result = pipeline.run_preprocessor(data=rawdata, xpos=None, offset=0)
+                            if "frames" not in result:
+                                raise KeyError("Pipeline result missing 'frames'")
+                            frame = result["frames"]
+                            for attr in ("waveform", "xpos", "label", "sampling_rate"):
+                                if not hasattr(frame, attr):
+                                    raise AttributeError(f"Frame missing attribute {attr}")
+                            frame_new = result["frames"]
+                            self._save_frame_to_temp(frame_new, frame_counter, h5f)
+                            frame_counter += 1
+                            del frame_new
+
+                self._logger.info(f"Saved temporary file: {temp_path.name} with {frame_counter} frames")
+
+            except (StopIteration, FileNotFoundError) as e:
+                self._logger.info(f"Missing data: {e}")
+                break
+
+            except Exception:
+                self._logger.exception("Failed loading data for %s", sets0.data_point)
+                raise
+
+            finally:
+                if datahandler is not None:
+                    del datahandler
+
+            current_index += 1
 
     def merge_data_from_all_iteration(self) -> str:
-        """Merging extracted information from all runs into one file
-        :return:    String with path to final file
+        """Merge all temporary HDF5 files into one final dataset.
+        The sampling rate is extracted from the first frame and stored as a scalar.
         """
-        folder_content = glob(join(self._path2save, "*.npy"))
-        folder_content.sort()
+        folder_content = sorted(Path(self._path2save).glob("*.h5"))
+        if not folder_content:
+            raise FileNotFoundError(f"No *.h5 files found in {self._path2save}")
 
-        file_name = folder_content[-1]
-        dataset_loaded = list()
-        for file in folder_content:
-            val = np.load(file, allow_pickle=True).item()["frames"]
-            dataset_loaded.append(val)
+        file_name = Path(folder_content[-1]).name
 
-        # --- Merging data from different sources
-        frames_waveform = list()
-        frames_position = list()
-        frames_label = list()
-        max_num_clusters = 0
-        for data_case in dataset_loaded:
-            for data_elec in data_case:
-                frames_waveform.extend(data_elec.waveform.tolist())
-                frames_position.extend(data_elec.xpos)
-                frames_label.extend(data_elec.label + max_num_clusters)
-                max_num_clusters += (
-                    0 if self._do_label_concatenation or len(frames_label) == 0 else 1 + max(frames_label)
-                )
+        path2folder = get_path_to_project("dataset")
+        Path(path2folder).mkdir(parents=True, exist_ok=True)
 
-        # --- Save output
-        data_merged = {
-            "data": np.array(frames_waveform),
-            "class": np.array(frames_label),
-            "position": np.array(frames_position),
-            "create_time": datetime.now().strftime("%Y-%m-%d"),
-        }
-        self._save_results(
-            data=data_merged,
-            path2folder=get_path_to_project("dataset"),
-            file_name=Path(file_name).stem + "_Merged",
-        )
-        return self._path2save
+        path2file = Path(path2folder) / f"{Path(file_name).stem}_Merged.h5"
+
+        label_collector = LabelCollector()
+        data_elec_counter = 0
+        sampling_rate = None
+
+        with h5py.File(path2file, "w") as h5f:
+            data_collector = CollectorH5(h5f, "data")
+            class_collector = CollectorH5(h5f, "class")
+            position_collector = CollectorH5(h5f, "position")
+
+            data_collector.define_datatype(np.float32)
+            class_collector.define_datatype(np.int32)
+            position_collector.define_datatype(np.int32)
+
+            for path in folder_content:
+                # write one frame at a time
+                for data_elec in self._iter_frames_from_temp(str(path)):
+                    if sampling_rate is None:
+                        sampling_rate = float(data_elec["sampling_rate"])
+
+                    waveforms = np.asarray(data_elec["waveform"], dtype=np.float32)
+                    if waveforms.ndim == 1:
+                        waveforms = waveforms[np.newaxis, :]
+
+                    positions = np.atleast_1d(np.asarray(data_elec["xpos"], dtype=np.int32))
+                    labels = np.atleast_1d(np.asarray(data_elec["label"], dtype=np.int32))
+
+                    if not (len(waveforms) == len(positions) == len(labels)):
+                        raise ValueError(
+                            f"Shape mismatch in {path}: \n"
+                            f"waveforms={len(waveforms)}, \n"
+                            f"positions={len(positions)}, \n"
+                            f"labels={len(labels)} \n"
+                        )
+
+                    for waveform, position, label in zip(waveforms, positions, labels):
+                        # emulate offset by combining keys
+                        if self._do_label_concatenation:
+                            label_key = int(label)
+                        else:
+                            label_key = f"{data_elec_counter}_{int(label)}"
+
+                        new_label = label_collector.add(label_key)
+
+                        data_collector.add(np.asarray(waveform, dtype=np.float32))
+                        position_collector.add(int(position))
+                        class_collector.add(int(new_label))
+
+                    data_elec_counter += 1
+
+            h5f.create_dataset(
+                "create_time",
+                data=np.array(
+                    datetime.now().strftime("%Y-%m-%d"),
+                    dtype=h5py.string_dtype(encoding="utf-8"),
+                ),
+            )
+
+            label_mapping = label_collector.get_all()
+            h5f.create_dataset(
+                "label_mapping_keys",
+                data=np.array(
+                    list(label_mapping.keys()),
+                    dtype=h5py.string_dtype(encoding="utf-8"),
+                ),
+            )
+            h5f.create_dataset(
+                "label_mapping_values",
+                data=np.array(
+                    list(label_mapping.values()),
+                    dtype=np.int32,
+                ),
+            )
+
+            if sampling_rate is not None:
+                h5f.create_dataset("sampling_rate", data=sampling_rate)
+            else:
+                self._logger.warning("No frames found – sampling_rate not set.")
+
+        self._logger.info(f"Final merged dataset saved to: {Path(path2file).name}")
+        return str(path2file)

--- a/denspp/offline/data_call/merge_datasets.py
+++ b/denspp/offline/data_call/merge_datasets.py
@@ -222,7 +222,7 @@ class MergeDataset:
                         # unlabeled dataset ----------------------------------------------------------------------------
                         pipeline = self._pipeline(data.fs_used, False)
                         for rawdata in tqdm(data.data_raw, ncols=100, desc="Progress (unlabeled): "):
-                            result = pipeline.run_preprocessor(data=rawdata, xpos=None, offset=0)
+                            result = pipeline.run_preprocessor(data=rawdata)
                             if "frames" not in result:
                                 raise KeyError("Pipeline result missing 'frames'")
                             frame = result["frames"]
@@ -304,7 +304,7 @@ class MergeDataset:
                         if self._do_label_concatenation:
                             label_key = int(label)
                         else:
-                            label_key = f"{data_elec_counter}_{int(label)}"
+                            label_key = f"{path.stem}_{int(label)}"
 
                         new_label = label_collector.add(label_key)
 

--- a/denspp/offline/data_call/merge_datasets_test.py
+++ b/denspp/offline/data_call/merge_datasets_test.py
@@ -1,29 +1,33 @@
-import shutil
 import unittest
 from glob import glob
 from os.path import join
 from pathlib import Path
-from unittest.mock import Mock
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
 
 import h5py
 import numpy as np
 
-from denspp.offline import get_path_to_project
 from denspp.offline.data_call.merge_datasets import MergeDataset
 from denspp.offline.preprocessing import FrameWaveform
 
 
 class MergeDatasetTest(unittest.TestCase):
     def setUp(self):
-        self.temp_dir = Path(get_path_to_project("temp_merge"))
-        if self.temp_dir.exists():
-            shutil.rmtree(self.temp_dir)
+        self._test_project_dir = TemporaryDirectory()
+        self.project_dir = Path(self._test_project_dir.name)
+
+        self.temp_dir = self.project_dir / "temp_merge"
         self.temp_dir.mkdir(exist_ok=True)
 
-        self.dataset_dir = Path(get_path_to_project("dataset"))
-        if self.dataset_dir.exists():
-            shutil.rmtree(self.dataset_dir)
+        self.dataset_dir = self.project_dir / "dataset"
         self.dataset_dir.mkdir(exist_ok=True)
+
+        self.get_path_patcher = patch(
+            "denspp.offline.data_call.merge_datasets.get_path_to_project",
+            side_effect=self._get_test_path_to_project,
+        )
+        self.get_path_patcher.start()
 
         self.pipeline_mock = Mock()
         self.pipeline_mock.run_preprocessor = Mock()
@@ -32,8 +36,12 @@ class MergeDatasetTest(unittest.TestCase):
         self.pipeline_mock.run_preprocessor.__name__ = "run_preprocessor"
         self.pipeline_mock.run_classifier.__name__ = "run_classifier"
         self.pipeline_mock.settings.__name__ = "settings"
+
         self.dataloader_mock = Mock()
         self.settings_mock = Mock()
+
+    def _get_test_path_to_project(self, folder_name):
+        return str(self.project_dir / folder_name)
 
     def _create_dummy_frame(self, waveform, xpos, label, sampling_rate=1000):
         return FrameWaveform(
@@ -181,10 +189,8 @@ class MergeDatasetTest(unittest.TestCase):
             self.assertEqual(set(h5f.keys()), expected_keys)
 
     def tearDown(self):
-        if self.temp_dir.exists():
-            shutil.rmtree(self.temp_dir)
-        if self.dataset_dir.exists():
-            shutil.rmtree(self.dataset_dir)
+        self.get_path_patcher.stop()
+        self._test_project_dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/denspp/offline/data_call/merge_datasets_test.py
+++ b/denspp/offline/data_call/merge_datasets_test.py
@@ -1,96 +1,190 @@
+import shutil
 import unittest
-from copy import deepcopy
 from glob import glob
 from os.path import join
+from pathlib import Path
+from unittest.mock import Mock
+
+import h5py
+import numpy as np
 
 from denspp.offline import get_path_to_project
-from denspp.offline.data_call import DefaultSettingsData
-from denspp.offline.pipeline import DataloaderLibrary, PipelineLibrary
-
-from .merge_datasets import MergeDataset
+from denspp.offline.data_call.merge_datasets import MergeDataset
+from denspp.offline.preprocessing import FrameWaveform
 
 
-@unittest.skip("API is broken due to stopped service")
 class MergeDatasetTest(unittest.TestCase):
     def setUp(self):
-        self.set0 = deepcopy(DefaultSettingsData)
-        self.set0.data_set = "martinez_with_labels"
-        self.pipe = (
-            PipelineLibrary().get_registry("denspp.offline.template").build_object(name="PipelineV0")
+        self.temp_dir = Path(get_path_to_project("temp_merge"))
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+        self.temp_dir.mkdir(exist_ok=True)
+
+        self.dataset_dir = Path(get_path_to_project("dataset"))
+        if self.dataset_dir.exists():
+            shutil.rmtree(self.dataset_dir)
+        self.dataset_dir.mkdir(exist_ok=True)
+
+        self.pipeline_mock = Mock()
+        self.pipeline_mock.run_preprocessor = Mock()
+        self.pipeline_mock.run_classifier = Mock()
+        self.pipeline_mock.settings = Mock()
+        self.pipeline_mock.run_preprocessor.__name__ = "run_preprocessor"
+        self.pipeline_mock.run_classifier.__name__ = "run_classifier"
+        self.pipeline_mock.settings.__name__ = "settings"
+        self.dataloader_mock = Mock()
+        self.settings_mock = Mock()
+
+    def _create_dummy_frame(self, waveform, xpos, label, sampling_rate=1000):
+        return FrameWaveform(
+            waveform=np.array(waveform, dtype=np.float32),
+            xpos=np.array([xpos], dtype=np.int32),
+            label=np.array([label], dtype=np.int32),
+            sampling_rate=sampling_rate,
         )
 
-    def test_merging_files_with_label_full(self):
-        data = (
-            DataloaderLibrary()
-            .get_registry("denspp.offline.template")
-            .build_object(name="DataLoaderTest")
-        )
+    def _save_dummy_dataset(self, file_name, frames_list):
+        self.temp_dir.mkdir(exist_ok=True)
+        path2file = self.temp_dir / file_name
+
+        waveforms = []
+        positions = []
+        labels = []
+
+        sampling_rate = frames_list[0].sampling_rate if frames_list else 1000
+
+        for frame in frames_list:
+            frame_waveforms = np.asarray(frame.waveform, dtype=np.float32)
+            if frame_waveforms.ndim == 1:
+                frame_waveforms = frame_waveforms[np.newaxis, :]
+
+            frame_positions = np.atleast_1d(np.asarray(frame.xpos, dtype=np.int32))
+            frame_labels = np.atleast_1d(np.asarray(frame.label, dtype=np.int32))
+
+            for waveform, xpos, label in zip(frame_waveforms, frame_positions, frame_labels):
+                waveforms.append(waveform)
+                positions.append(xpos)
+                labels.append(label)
+
+        with h5py.File(path2file, "w") as h5f:
+            h5f.create_dataset("waveform", data=np.asarray(waveforms, dtype=np.float32))
+            h5f.create_dataset("xpos", data=np.asarray(positions, dtype=np.int32))
+            h5f.create_dataset("label", data=np.asarray(labels, dtype=np.int32))
+            h5f.create_dataset("sampling_rate", data=np.asarray(sampling_rate))
+
+    def test_merge_without_concatenation(self):
+        ds1 = [
+            self._create_dummy_frame([1, 2, 3], 10, 0),
+            self._create_dummy_frame([4, 5, 6], 20, 1),
+        ]
+        ds2 = [
+            self._create_dummy_frame([7, 8, 9], 30, 0),
+            self._create_dummy_frame([10, 11, 12], 40, 2),
+            self._create_dummy_frame([13, 14, 15], 50, 5),
+        ]
+        ds3 = [
+            self._create_dummy_frame([16, 17, 18], 60, 3),
+        ]
+
+        self._save_dummy_dataset("2024-01-01_Dataset-A.h5", ds1)
+        self._save_dummy_dataset("2024-01-02_Dataset-B.h5", ds2)
+        self._save_dummy_dataset("2024-01-03_Dataset-C.h5", ds3)
+
         dut = MergeDataset(
-            pipeline=self.pipe,
-            dataloader=data,
-            settings_data=self.set0,
+            pipeline=self.pipeline_mock,
+            dataloader=self.dataloader_mock,
+            settings_data=self.settings_mock,
             concatenate_id=False,
         )
-        dut.get_frames_from_dataset(process_points=list(), xpos_offset=0)
-        self.assertEqual(len(glob(join(get_path_to_project("temp_merge"), "*.npy"))), 5)
         dut.merge_data_from_all_iteration()
-        self.assertTrue(
-            any(
-                [
-                    "_Dataset-martinezsimulation_5_Merged" in file_name
-                    for file_name in glob(join(get_path_to_project(), "dataset", "*.npy"))
-                ]
-            )
+
+        merged_files = sorted(glob(join(self.dataset_dir, "*_Merged.h5")))
+        self.assertEqual(len(merged_files), 1)
+
+        with h5py.File(merged_files[0], "r") as h5f:
+            merged_data = {
+                "data": np.array(h5f["data"][()]),
+                "class": np.array(h5f["class"][()]),
+                "position": np.array(h5f["position"][()]),
+            }
+
+        labels = merged_data["class"]
+        expected_labels = np.array([0, 1, 2, 3, 4, 5])
+        np.testing.assert_array_equal(labels, expected_labels)
+
+    def test_merge_with_concatenation(self):
+        ds1 = [
+            self._create_dummy_frame([1, 2, 3], 10, 0),
+            self._create_dummy_frame([4, 5, 6], 20, 1),
+        ]
+        ds2 = [
+            self._create_dummy_frame([7, 8, 9], 30, 0),
+            self._create_dummy_frame([10, 11, 12], 40, 2),
+        ]
+
+        self._save_dummy_dataset("2024-01-01_Dataset-A.h5", ds1)
+        self._save_dummy_dataset("2024-01-02_Dataset-B.h5", ds2)
+
+        dut = MergeDataset(
+            pipeline=self.pipeline_mock,
+            dataloader=self.dataloader_mock,
+            settings_data=self.settings_mock,
+            concatenate_id=True,
+        )
+        dut.merge_data_from_all_iteration()
+
+        merged_files = sorted(glob(join(self.dataset_dir, "*_Merged.h5")))
+        self.assertEqual(len(merged_files), 1)
+
+        with h5py.File(merged_files[0], "r") as h5f:
+            merged_data = {
+                "data": np.array(h5f["data"][()]),
+                "class": np.array(h5f["class"][()]),
+                "position": np.array(h5f["position"][()]),
+            }
+
+        labels = merged_data["class"]
+        expected_labels = np.array([0, 1, 0, 2])
+        np.testing.assert_array_equal(labels, expected_labels)
+
+    def test_expected_keys(self):
+        expected_keys = {
+            "data",
+            "class",
+            "position",
+            "sampling_rate",
+            "create_time",
+            "label_mapping_keys",
+            "label_mapping_values",
+        }
+
+        ds1 = [
+            self._create_dummy_frame([1, 2, 3], 10, 0),
+            self._create_dummy_frame([4, 5, 6], 20, 1),
+        ]
+
+        self._save_dummy_dataset("2024-01-01_Dataset-A.h5", ds1)
+
+        dut = MergeDataset(
+            pipeline=self.pipeline_mock,
+            dataloader=self.dataloader_mock,
+            settings_data=self.settings_mock,
+            concatenate_id=False,
         )
 
-    def test_merging_files_with_label_half(self):
-        data = (
-            DataloaderLibrary()
-            .get_registry("denspp.offline.template")
-            .build_object(name="DataLoaderTest")
-        )
-        dut = MergeDataset(
-            pipeline=self.pipe,
-            dataloader=data,
-            settings_data=self.set0,
-            concatenate_id=False,
-        )
-        dut.get_frames_from_dataset(process_points=[1, 3], xpos_offset=0)
-        self.assertEqual(len(glob(join(get_path_to_project("temp_merge"), "*.npy"))), 2)
         dut.merge_data_from_all_iteration()
-        self.assertTrue(
-            any(
-                [
-                    "_Dataset-martinezsimulation_4_Merged" in file_name
-                    for file_name in glob(join(get_path_to_project(), "dataset", "*.npy"))
-                ]
-            )
-        )
 
-    def test_merging_files_without_label(self):
-        self.set0.data_set = "martinez_without_labels"
-        data = (
-            DataloaderLibrary()
-            .get_registry("denspp.offline.template")
-            .build_object(name="DataLoaderTest")
-        )
-        dut = MergeDataset(
-            pipeline=self.pipe,
-            dataloader=data,
-            settings_data=self.set0,
-            concatenate_id=False,
-        )
-        dut.get_frames_from_dataset(process_points=[], xpos_offset=0)
-        self.assertEqual(len(glob(join(get_path_to_project("temp_merge"), "*.npy"))), 5)
-        dut.merge_data_from_all_iteration()
-        self.assertTrue(
-            any(
-                [
-                    "_Dataset-martinezsimulation_5_Merged" in file_name
-                    for file_name in glob(join(get_path_to_project(), "dataset", "*.npy"))
-                ]
-            )
-        )
+        merged_files = sorted(glob(join(self.dataset_dir, "*_Merged.h5")))
+        self.assertEqual(len(merged_files), 1)
+
+        with h5py.File(merged_files[0], "r") as h5f:
+            self.assertEqual(set(h5f.keys()), expected_keys)
+
+    def tearDown(self):
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+        if self.dataset_dir.exists():
+            shutil.rmtree(self.dataset_dir)
 
 
 if __name__ == "__main__":

--- a/denspp/offline/dnn/data_config.py
+++ b/denspp/offline/dnn/data_config.py
@@ -92,7 +92,7 @@ class ControllerDataset:
         self._settings = settings
         self._logger = getLogger(__name__)
         self._methods = self._extract_func(self.__class__)
-        self._path = get_path_to_project() / temp_folder
+        self._path = (get_path_to_project() / temp_folder).resolve().absolute()
 
     @property
     def get_overview_methods(self) -> list:
@@ -137,25 +137,19 @@ class ControllerDataset:
         else:
             return getattr(self, self._methods[idx])()
 
-    def print_overview_datasets(self, do_print: bool = True) -> list:
+    def print_overview_datasets(self) -> list:
         """Giving an overview of available datasets on the cloud storage
         :return:            Return a list with dataset names
         """
         oc_handler = OwnCloudDownloader(path2config=self._path)
         list_datasets = self._extract_methods(self._index_search[1])
         list_datasets.extend(oc_handler.get_overview_data(use_dataset=True))
-        if do_print:
-            self._logger.info("\nAvailable datasets in repository and from remote:")
-            self._logger.info("==================================================")
-            for idx, file in enumerate(list_datasets):
-                self._logger.info(f"\t{idx}: \t{file}")
-
         oc_handler.close()
         return list_datasets
 
     def print_dataset_properties(self, data: DatasetFromFile) -> None:
         """Printing the properties of the loaded dataset
-        :param data:    Dataclas DatasetFromFile loaded externally
+        :param data:    Dataclass DatasetFromFile loaded externally
         :return:        None
         """
         check = np.unique(data.label, return_counts=True)

--- a/denspp/offline/dnn/data_config_test.py
+++ b/denspp/offline/dnn/data_config_test.py
@@ -52,9 +52,7 @@ class TestDatasetConfig(TestCase):
     def setUp(self):
         self.sets: SettingsDataset = deepcopy(TestSettingsDataset)
         path2json = Path(get_path_to_project("temp_test")) / "access_cloud.json"
-        if path2json.exists():
-            path2json.unlink()
-            JsonHandler(template=TestConfigCloud, path=path2json.parent, file_name=path2json.name)
+        JsonHandler(template=TestConfigCloud, path=path2json.parent, file_name=path2json.name)
 
     def test_get_dataset_overview(self):
         self.sets.data_type = ""
@@ -63,9 +61,7 @@ class TestDatasetConfig(TestCase):
 
     def test_dataset_overview(self):
         self.sets.data_type = "mnist"
-        overview = DatasetLoader(settings=self.sets, temp_folder="temp_test").print_overview_datasets(
-            do_print=False
-        )
+        overview = DatasetLoader(settings=self.sets, temp_folder="temp_test").print_overview_datasets()
         self.assertGreaterEqual(len(overview), 3)
         assert self.sets.data_type in overview
 
@@ -73,18 +69,19 @@ class TestDatasetConfig(TestCase):
         self.sets.data_type = ""
         try:
             DatasetLoader(settings=self.sets).load_dataset(do_print=False)
-            self.assertTrue(False)
         except:
             self.assertTrue(True)
+        else:
+            self.assertTrue(False)
 
-    @pytest.mark.init
     def test_dataset_remote(self):
         self.sets.data_type = "martinez"
         try:
-            DatasetLoader(settings=self.sets).load_dataset(do_print=False)
-            self.assertTrue(True)
+            DatasetLoader(settings=self.sets, temp_folder="temp_test").load_dataset(do_print=False)
         except:
             self.assertTrue(False)
+        else:
+            self.assertTrue(True)
 
     @pytest.mark.slow
     def test_dataset_mnist(self):

--- a/denspp/offline/structure_builder.py
+++ b/denspp/offline/structure_builder.py
@@ -72,7 +72,4 @@ def init_dnn_folder(new_folder: str = "") -> None:
         if not path2start.exists():
             logger.debug(f"Creating template folder: {folder_name}")
 
-    copy_template_files(
-        copy_files=copy_files,
-        path2start=path2start
-    )
+    copy_template_files(copy_files=copy_files, path2start=path2start)

--- a/denspp/offline/template/call_dataset.py
+++ b/denspp/offline/template/call_dataset.py
@@ -18,7 +18,6 @@ class DatasetLoader(ControllerDataset):
     _logger: Logger
     _settings: SettingsDataset
     _processor: DataProcessor
-    _path: str
 
     def __init__(self, settings: SettingsDataset, temp_folder: str = "") -> None:
         """Class for downloading (function name with '__get_xyz')
@@ -75,8 +74,8 @@ class DatasetLoader(ControllerDataset):
             else:
                 x = np.cos(window)
                 label = 1
-            x += noise_amp * np.random.randn(seq_len)  # kleines Rauschen
-            data.append(x)  # shape: (seq_len, 1)
+            x += noise_amp * np.random.randn(seq_len)
+            data.append(x)
             labels.append(label)
 
         dataset = DatasetFromFile(


### PR DESCRIPTION
## Summary

This PR migrates the dataset merge workflow from `.npy` storage to HDF5 (`.h5`) files.

The new implementation writes and reads data incrementally, so the full dataset does not need to be kept in memory during merging.

## Changes

- Replaced temporary `.npy` merge files with HDF5 (`.h5`) files.
- Replaced pickle-based storage of `FrameWaveform` objects with explicit HDF5 datasets.
- Added a flat temporary HDF5 structure:

```text
temp_merge/
└── YYYY-MM-DD_Dataset-<data_name>.h5
    ├── waveform
    ├── xpos
    ├── label
    └── sampling_rate 
```

- The final merged dataset is stored as:
```text
dataset/
└── YYYY-MM-DD_Dataset-<data_name>_Merged.h5
    ├── data
    ├── class
    ├── position
    ├── sampling_rate
    ├── create_time
    ├── label_mapping_keys
    └── label_mapping_values
```

## Related Issue
Closes #137